### PR TITLE
Update XIQ-IPFirewall-Config_v1.py

### DIFF
--- a/XIQ-IPFirewall-Config_v1.py
+++ b/XIQ-IPFirewall-Config_v1.py
@@ -49,7 +49,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module='openpyxl') # Sup
 # XIQ_password = getpass.getpass("Password: ")
 
 ## 3) TOKEN generation from api.extremecloudiq.com (Swagger). Must have empty username and password variables (Uncomment 3 total lines below).  Enter XIQ Token within "" only.
-# XIQ_Token = "XXXXXXXXXXXX"
+XIQ_Token = "XXXXXXXXXXXX"
 XIQ_username = ""
 XIQ_password = ""
 ##Authentication Options END


### PR DESCRIPTION
Line 52 was commented out by mistake.  This line is for XIQ_Token = "<token>" under Option 3 Token generation.